### PR TITLE
Fix: Some buttons had white text and white bg

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -236,7 +236,7 @@ div.ac-wrap,
 }
 
 .btn-text {
-  background-color: $color-white;
+  color: $color-white;
 }
 
 //


### PR DESCRIPTION
Some buttons had white text and a white background color, making it difficult to read:

-  'Save Edit' button in the category edit modal
- 'Install' button in the install modal at Admin > Customize > Themes (after you put a URL for the GitHub repository)